### PR TITLE
ISDMISSSTC-320: (Complete) Splash screen lang buttons correct behavior

### DIFF
--- a/src/components/Language/Localization.js
+++ b/src/components/Language/Localization.js
@@ -22,6 +22,7 @@ export default class Localization {
                 general: General.fr
             }
         });
+
         const lang = localStorage.getItem("lang");
 
         if (lang) {

--- a/src/routes/Splash/Splash.js
+++ b/src/routes/Splash/Splash.js
@@ -107,14 +107,14 @@ class Splash extends Component {
                             forced labor, and human trafficking worldwide.
                         </SubText>
                     </SplashHeader>
-                    <LanguageWrapper id="splash-language-switcher">
+                    <LanguageWrapper id="language-switcher">
                         <LanguageButton
                             id="en-btn"
                             onClick={() => {
                                 this.handleLanguageChange("en");
                             }}
                         >
-                            English
+                            <span lang="en">{this.props.localizor.strings.general.english}</span>
                         </LanguageButton>
                         <LanguageButton
                             id="es-btn"
@@ -122,7 +122,7 @@ class Splash extends Component {
                                 this.handleLanguageChange("es");
                             }}
                         >
-                            Español
+                            <span lang="es">{this.props.localizor.strings.general.spanish}</span>
                         </LanguageButton>
                         <LanguageButton
                             id="fr-btn"
@@ -130,7 +130,7 @@ class Splash extends Component {
                                 this.handleLanguageChange("fr");
                             }}
                         >
-                            Français
+                            <span lang="fr">{this.props.localizor.strings.general.french}</span>
                         </LanguageButton>
                     </LanguageWrapper>
                 </FlexContent>


### PR DESCRIPTION
The language buttons on the Splash screen did not have spans and did not use localization strings. Now when the interface language is, for example Spanish, the Splash screen language labels are in Spanish and not English.